### PR TITLE
Handle nil pointer exception for existing buckets

### DIFF
--- a/pkg/driver/fake/s3client/fake_s3client.go
+++ b/pkg/driver/fake/s3client/fake_s3client.go
@@ -19,6 +19,7 @@ package s3client
 import (
 	"errors"
 	"github.com/IBM/satellite-object-storage-plugin/pkg/s3client"
+	"go.uber.org/zap"
 )
 
 // ObjectStorageSessionFactory is a factory for mocked object storage sessions
@@ -50,15 +51,17 @@ type ObjectStorageSessionFactory struct {
 
 type fakeObjectStorageSession struct {
 	factory *ObjectStorageSessionFactory
+	logger  *zap.Logger
 }
 
 // NewObjectStorageSession method creates a new fake object store session
-func (f *ObjectStorageSessionFactory) NewObjectStorageSession(endpoint, region string, creds *s3client.ObjectStorageCredentials) s3client.ObjectStorageSession {
+func (f *ObjectStorageSessionFactory) NewObjectStorageSession(endpoint, region string, creds *s3client.ObjectStorageCredentials, lgr *zap.Logger) s3client.ObjectStorageSession {
 	f.LastEndpoint = endpoint
 	f.LastRegion = region
 	f.LastCredentials = creds
 	return &fakeObjectStorageSession{
 		factory: f,
+		logger:  lgr,
 	}
 }
 

--- a/pkg/driver/s3-driver.go
+++ b/pkg/driver/s3-driver.go
@@ -110,10 +110,11 @@ func newIdentityServer(d *S3Driver) *identityServer {
 	}
 }
 
-func newControllerServer(d *S3Driver, s3cosSession s3client.ObjectStorageSessionFactory) *controllerServer {
+func newControllerServer(d *S3Driver, s3cosSession s3client.ObjectStorageSessionFactory, logger *zap.Logger) *controllerServer {
 	return &controllerServer{
 		S3Driver:   d,
 		cosSession: s3cosSession,
+		Logger:     logger,
 	}
 }
 
@@ -161,11 +162,11 @@ func (driver *S3Driver) NewS3CosDriver(nodeID string, endpoint string, s3cosSess
 	// Create GRPC servers
 	driver.ids = newIdentityServer(driver)
 	if driver.mode == "controller" {
-		driver.cs = newControllerServer(driver, s3cosSession)
+		driver.cs = newControllerServer(driver, s3cosSession, driver.logger)
 	} else if driver.mode == "node" {
 		driver.ns = newNodeServer(driver, nodeID, mountObj)
 	} else if driver.mode == "controller-node" {
-		driver.cs = newControllerServer(driver, s3cosSession)
+		driver.cs = newControllerServer(driver, s3cosSession, driver.logger)
 		driver.ns = newNodeServer(driver, nodeID, mountObj)
 	}
 

--- a/pkg/s3client/s3client.go
+++ b/pkg/s3client/s3client.go
@@ -67,7 +67,7 @@ type COSSessionFactory struct{}
 type ObjectStorageSessionFactory interface {
 
 	// NewObjectStorageBackend method creates a new object store session
-	NewObjectStorageSession(endpoint, locationConstraint string, creds *ObjectStorageCredentials) ObjectStorageSession
+	NewObjectStorageSession(endpoint, locationConstraint string, creds *ObjectStorageCredentials, lgr *zap.Logger) ObjectStorageSession
 }
 
 var _ ObjectStorageSessionFactory = &COSSessionFactory{}
@@ -180,7 +180,7 @@ func NewS3Client(lgr *zap.Logger) (ObjectStorageSession, error) {
 }
 
 // NewObjectStorageSession method creates a new object store session
-func (s *COSSessionFactory) NewObjectStorageSession(endpoint, locationConstraint string, creds *ObjectStorageCredentials) ObjectStorageSession {
+func (s *COSSessionFactory) NewObjectStorageSession(endpoint, locationConstraint string, creds *ObjectStorageCredentials, lgr *zap.Logger) ObjectStorageSession {
 	var sdkCreds *credentials.Credentials
 	if creds.AuthType == "iam" {
 		sdkCreds = ibmiam.NewStaticCredentials(aws.NewConfig(), creds.IAMEndpoint+"/identity/token", creds.APIKey, creds.ServiceInstanceID)
@@ -195,6 +195,7 @@ func (s *COSSessionFactory) NewObjectStorageSession(endpoint, locationConstraint
 	}))
 
 	return &COSSession{
-		svc: s3.New(sess),
+		svc:    s3.New(sess),
+		logger: lgr,
 	}
 }

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/IBM/satellite-object-storage-plugin/pkg/s3client"
 	"github.com/google/uuid"
 	sanity "github.com/kubernetes-csi/csi-test/v4/pkg/sanity"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/klog/v2"
@@ -114,6 +115,7 @@ var _ s3client.ObjectStorageSessionFactory = &FakeObjectStorageSessionFactory{}
 
 type fakeObjectStorageSession struct {
 	factory *FakeObjectStorageSessionFactory
+	logger  *zap.Logger
 }
 
 func NewObjectStorageSessionFactory() *FakeObjectStorageSessionFactory {
@@ -121,9 +123,10 @@ func NewObjectStorageSessionFactory() *FakeObjectStorageSessionFactory {
 }
 
 // NewObjectStorageSession method creates a new object store session
-func (f *FakeObjectStorageSessionFactory) NewObjectStorageSession(endpoint, locationConstraint string, creds *s3client.ObjectStorageCredentials) s3client.ObjectStorageSession {
+func (f *FakeObjectStorageSessionFactory) NewObjectStorageSession(endpoint, locationConstraint string, creds *s3client.ObjectStorageCredentials, lgr *zap.Logger) s3client.ObjectStorageSession {
 	return &fakeObjectStorageSession{
 		factory: f,
+		logger:  lgr,
 	}
 }
 


### PR DESCRIPTION
While testing existing bucket usage, controller pod was going to CrashLoop due to NilPointer Exception.